### PR TITLE
Adding actions factory

### DIFF
--- a/src/actions-factory.js
+++ b/src/actions-factory.js
@@ -4,9 +4,9 @@
 
 "use strict";
 
-import { leftAction, rightAction, moveAction, placeAction } from './actions';
+import { leftAction, rightAction, moveAction, placeAction } from './actions.js';
 
-export const actionFactory = (input) => {
+export const actionsFactory = (input) => {
     let inputString = input.trim();
     let placeArray = inputString.match(/^(PLACE)(\s)*([0-9]+)([,\s]*)([0-9]+)([,\s]*)(EAST|WEST|NORTH|SOUTH)*$/);
 
@@ -23,5 +23,4 @@ export const actionFactory = (input) => {
     } else {
         return {type: 'UNDEFINED_ACTION'}
     }
-
 };

--- a/src/actions-factory.js
+++ b/src/actions-factory.js
@@ -1,0 +1,27 @@
+/**
+ * Created by einarvalur on 15/09/2016.
+ */
+
+"use strict";
+
+import { leftAction, rightAction, moveAction, placeAction } from './actions';
+
+export const actionFactory = (input) => {
+    let inputString = input.trim();
+    let placeArray = inputString.match(/^(PLACE)(\s)*([0-9]+)([,\s]*)([0-9]+)([,\s]*)(EAST|WEST|NORTH|SOUTH)*$/);
+
+    if (placeArray) {
+        return placeAction(parseInt(placeArray[3]), parseInt(placeArray[5]), placeArray[7]);
+    } else if (inputString == 'MOVE') {
+        return moveAction();
+    } else if (inputString == 'LEFT') {
+        return leftAction();
+    } else if (inputString == 'RIGHT') {
+        return rightAction();
+    } else if (inputString == 'REPORT') {
+        return {type: 'REPORT'}
+    } else {
+        return {type: 'UNDEFINED_ACTION'}
+    }
+
+};

--- a/test/actions-factory.spec.js
+++ b/test/actions-factory.spec.js
@@ -5,9 +5,9 @@
 'use strict';
 
 import assert from 'assert';
-import { actionFactory } from '../src/actions-factory.js';
+import { actionsFactory } from '../src/actions-factory.js';
 
-describe('Action factory', () => {
+describe('Actions factory', () => {
     it('should return PLACE action', () => {
         let expectedAction = {
             type: 'PLACE',
@@ -16,12 +16,12 @@ describe('Action factory', () => {
             orientation: 'SOUTH'
         };
 
-        let action1 = actionFactory('PLACE 1 2 SOUTH');
-        let action2 = actionFactory('PLACE 1, 2, SOUTH');
-        let action3 = actionFactory('PLACE 1    2, SOUTH');
-        let action4 = actionFactory('PLACE 1    2');
-        let action5 = actionFactory('PLACE   1    2,');
-        let action6 = actionFactory('  PLACE   1    2  ');
+        let action1 = actionsFactory('PLACE 1 2 SOUTH');
+        let action2 = actionsFactory('PLACE 1, 2, SOUTH');
+        let action3 = actionsFactory('PLACE 1    2, SOUTH');
+        let action4 = actionsFactory('PLACE 1    2');
+        let action5 = actionsFactory('PLACE   1    2,');
+        let action6 = actionsFactory('  PLACE   1    2  ');
 
         assert.deepStrictEqual(action1, expectedAction);
         assert.deepStrictEqual(action2, expectedAction);
@@ -34,8 +34,8 @@ describe('Action factory', () => {
     it('should return MOVE action', () => {
         let expectedAction = {type: 'MOVE'};
 
-        let action1 = actionFactory('MOVE');
-        let action2 = actionFactory(' MOVE ');
+        let action1 = actionsFactory('MOVE');
+        let action2 = actionsFactory(' MOVE ');
 
         assert.deepStrictEqual(action1, expectedAction);
         assert.deepStrictEqual(action2, expectedAction);
@@ -44,8 +44,8 @@ describe('Action factory', () => {
     it('should return LEFT action', () => {
         let expectedAction = {type: 'LEFT'};
 
-        let action1 = actionFactory('LEFT');
-        let action2 = actionFactory(' LEFT ');
+        let action1 = actionsFactory('LEFT');
+        let action2 = actionsFactory(' LEFT ');
 
         assert.deepStrictEqual(action1, expectedAction);
         assert.deepStrictEqual(action2, expectedAction);
@@ -54,8 +54,8 @@ describe('Action factory', () => {
     it('should return RIGHT action', () => {
         let expectedAction = {type: 'RIGHT'};
 
-        let action1 = actionFactory('RIGHT');
-        let action2 = actionFactory(' RIGHT ');
+        let action1 = actionsFactory('RIGHT');
+        let action2 = actionsFactory(' RIGHT ');
 
         assert.deepStrictEqual(action1, expectedAction);
         assert.deepStrictEqual(action2, expectedAction);
@@ -64,11 +64,11 @@ describe('Action factory', () => {
     it('should return UNDEFINED_ACTION', () => {
         let expectedAction = {type: 'UNDEFINED_ACTION'};
 
-        let action1 = actionFactory('RANDOM INPUT');
-        let action2 = actionFactory('PLACE 1 2 SOUTH-WEST');
-        let action3 = actionFactory('PLACE 1 y SOUTH');
-        let action4 = actionFactory('place 1 2 south');
-        let action5 = actionFactory('PLACE');
+        let action1 = actionsFactory('RANDOM INPUT');
+        let action2 = actionsFactory('PLACE 1 2 SOUTH-WEST');
+        let action3 = actionsFactory('PLACE 1 y SOUTH');
+        let action4 = actionsFactory('place 1 2 south');
+        let action5 = actionsFactory('PLACE');
 
         assert.deepStrictEqual(action1, expectedAction);
         assert.deepStrictEqual(action2, expectedAction);

--- a/test/actions-factory.spec.js
+++ b/test/actions-factory.spec.js
@@ -1,0 +1,79 @@
+/**
+ * Created by einarvalur on 15/09/2016.
+ */
+
+'use strict';
+
+import assert from 'assert';
+import { actionFactory } from '../src/actions-factory.js';
+
+describe('Action factory', () => {
+    it('should return PLACE action', () => {
+        let expectedAction = {
+            type: 'PLACE',
+            x: 1,
+            y: 2,
+            orientation: 'SOUTH'
+        };
+
+        let action1 = actionFactory('PLACE 1 2 SOUTH');
+        let action2 = actionFactory('PLACE 1, 2, SOUTH');
+        let action3 = actionFactory('PLACE 1    2, SOUTH');
+        let action4 = actionFactory('PLACE 1    2');
+        let action5 = actionFactory('PLACE   1    2,');
+        let action6 = actionFactory('  PLACE   1    2  ');
+
+        assert.deepStrictEqual(action1, expectedAction);
+        assert.deepStrictEqual(action2, expectedAction);
+        assert.deepStrictEqual(action3, expectedAction);
+        assert.deepStrictEqual(action4, expectedAction);
+        assert.deepStrictEqual(action5, expectedAction);
+        assert.deepStrictEqual(action6, expectedAction);
+    });
+
+    it('should return MOVE action', () => {
+        let expectedAction = {type: 'MOVE'};
+
+        let action1 = actionFactory('MOVE');
+        let action2 = actionFactory(' MOVE ');
+
+        assert.deepStrictEqual(action1, expectedAction);
+        assert.deepStrictEqual(action2, expectedAction);
+    });
+
+    it('should return LEFT action', () => {
+        let expectedAction = {type: 'LEFT'};
+
+        let action1 = actionFactory('LEFT');
+        let action2 = actionFactory(' LEFT ');
+
+        assert.deepStrictEqual(action1, expectedAction);
+        assert.deepStrictEqual(action2, expectedAction);
+    });
+
+    it('should return RIGHT action', () => {
+        let expectedAction = {type: 'RIGHT'};
+
+        let action1 = actionFactory('RIGHT');
+        let action2 = actionFactory(' RIGHT ');
+
+        assert.deepStrictEqual(action1, expectedAction);
+        assert.deepStrictEqual(action2, expectedAction);
+    });
+
+    it('should return UNDEFINED_ACTION', () => {
+        let expectedAction = {type: 'UNDEFINED_ACTION'};
+
+        let action1 = actionFactory('RANDOM INPUT');
+        let action2 = actionFactory('PLACE 1 2 SOUTH-WEST');
+        let action3 = actionFactory('PLACE 1 y SOUTH');
+        let action4 = actionFactory('place 1 2 south');
+        let action5 = actionFactory('PLACE');
+
+        assert.deepStrictEqual(action1, expectedAction);
+        assert.deepStrictEqual(action2, expectedAction);
+        assert.deepStrictEqual(action3, expectedAction);
+        assert.deepStrictEqual(action4, expectedAction);
+        assert.deepStrictEqual(action5, expectedAction);
+    });
+});


### PR DESCRIPTION
## What?

Since this is a command-line application, user's input will come as a text string. The application needs to translate that into `actions`. This PR adds that
## How?

The state of the application is drive by `actions`. The user is picking different `actions` by typing in commands into the terminal.

These commands have to be translated into correct actions. This calls for a **factory**. This factory will accepts `String` and return correct actions or provide an error message if the command is not understood.

Since the user is typing in these commands by hand, the **factory** has to be somewhat forgiven. Event not required... I think all of these variations for the `PLACE` command should be valid
- `PLACE 1 2 SOUTH`
- `PLACE 1, 2, SOUTH`
- `PLACE 1    2, SOUTH`

...but in return, the input is case-sensitive, so this will NOT be valid input
- `PLACE 1 2 south`
- `place 1, 2, SOUTH`
- `PlAcE 1    2, SoUtH`
## TODO
- [x] Write/Test factory
  - [x] Write a somewhat forgiven RegEx input validator
